### PR TITLE
Opportunistically tries to strip the BOM of a configuration file if any.

### DIFF
--- a/src/ConfigLoader.ts
+++ b/src/ConfigLoader.ts
@@ -1,34 +1,37 @@
 /// <reference path="../typings/main/ambient/node/index.d.ts" />
 
-namespace TSLint.MSBuild.ConfigLoader {
+namespace TSLint.MSBuild {
     "use strict";
 
     const fs = require("fs"),
         path = require("path");
 
-    /**
-     * Reads and deserializes a tslint.json file.
-     * @param path  The path of the file.
-     * @returns A promise with the configuration object.
-     */
-    export function readJSONConfig(path: string) {
-        return new Promise((resolve, reject) => {
-            fs.readFile(path, (error, result) => {
-                if (error) {
-                    reject(error);
-                } else {
-                    resolve(JSON.parse(stripBomIfNeeded(result.toString())));
-                }
-            });
-        });
-    }
+    export class ConfigLoader {
 
-    /**
-     * Strips BOM if any.
-     * @param content   the raw content of a file.
-     * @returns The content with the BOM stripped.
-     */
-    function stripBomIfNeeded(content: string) {
-        return content.replace(/^\uFEFF/, "");
+        /**
+         * Reads and deserializes a tslint.json file.
+         * @param path  The path of the file.
+         * @returns A promise with the configuration object.
+         */
+        public readJSONConfig(path: string) {
+            return new Promise((resolve, reject) => {
+                fs.readFile(path, (error, result) => {
+                    if (error) {
+                        reject(error);
+                    } else {
+                        resolve(JSON.parse(ConfigLoader.stripBomIfNeeded(result.toString())));
+                    }
+                });
+            });
+        }
+
+        /**
+         * Strips BOM if any.
+         * @param content   the raw content of a file.
+         * @returns The content with the BOM stripped.
+         */
+        static stripBomIfNeeded(content: string) {
+            return content.replace(/^\uFEFF/, "");
+        }
     }
 }

--- a/src/ConfigLoader.ts
+++ b/src/ConfigLoader.ts
@@ -1,0 +1,34 @@
+/// <reference path="../typings/main/ambient/node/index.d.ts" />
+
+namespace TSLint.MSBuild.ConfigLoader {
+    "use strict";
+
+    const fs = require("fs"),
+        path = require("path");
+
+    /**
+     * Reads and deserializes a tslint.json file.
+     * @param path  The path of the file.
+     * @returns A promise with the configuration object.
+     */
+    export function readJSONConfig(path: string) {
+        return new Promise((resolve, reject) => {
+            fs.readFile(path, (error, result) => {
+                if (error) {
+                    reject(error);
+                } else {
+                    resolve(JSON.parse(stripBomIfNeeded(result.toString())));
+                }
+            });
+        });
+    }
+
+    /**
+     * Strips BOM if any.
+     * @param content   the raw content of a file.
+     * @returns The content with the BOM stripped.
+     */
+    function stripBomIfNeeded(content: string) {
+        return content.replace(/^\uFEFF/, "");
+    }
+}

--- a/src/Folder.ts
+++ b/src/Folder.ts
@@ -98,7 +98,6 @@ namespace TSLint.MSBuild {
                 })
                 .catch((error) => {
                     this.setTSLintConfig(undefined);
-                    return false;
                 });
         }
 

--- a/src/Folder.ts
+++ b/src/Folder.ts
@@ -35,8 +35,9 @@ namespace TSLint.MSBuild {
          * Initializes a new instance of the Folder class.
          * 
          * @param path   The path to this folder.
+         * @param configLoader  The configuration loader.
          */
-        constructor(path: string) {
+        constructor(path: string, private configLoader: ConfigLoader) {
             this.path = path;
         }
 
@@ -87,7 +88,7 @@ namespace TSLint.MSBuild {
          */
         public loadTSLintConfig(): Promise<boolean> {
             this.loadWaiter.markActionStart();
-            return ConfigLoader
+            return this.configLoader
                 .readJSONConfig(path.join(this.path, "tslint.json"))
                 .then((config) => {
                     this.setTSLintConfig({

--- a/src/Folder.ts
+++ b/src/Folder.ts
@@ -1,12 +1,12 @@
 /// <reference path="../typings/main/ambient/node/index.d.ts" />
 /// <reference path="WaitLock.ts" />
+/// <reference path="./ConfigLoader.ts" />
 
 namespace TSLint.MSBuild {
     "use strict";
 
     let fs = require("fs"),
         path = require("path");
-
     /**
      * A representation of a directory with files and optionally a tsconfig.json.
      */
@@ -44,7 +44,7 @@ namespace TSLint.MSBuild {
          * @returns The path to this folder.
          */
         public getPath(): string {
-           return this.path;
+            return this.path;
         }
 
         /**
@@ -87,23 +87,19 @@ namespace TSLint.MSBuild {
          */
         public loadTSLintConfig(): Promise<boolean> {
             this.loadWaiter.markActionStart();
-
-            return new Promise(resolve => {
-                fs.readFile(path.join(this.path, "tslint.json"), (error, result) => {
-                    if (error) {
-                        this.setTSLintConfig(undefined);
-                        resolve(false);
-                        return;
-                    }
-
+            return ConfigLoader
+                .readJSONConfig(path.join(this.path, "tslint.json"))
+                .then((config) => {
                     this.setTSLintConfig({
                         formatter: "json",
-                        configuration: JSON.parse(result.toString())
+                        configuration: config
                     });
-
-                    resolve(true);
+                    return true;
+                })
+                .catch((error) => {
+                    this.setTSLintConfig(undefined);
+                    return false;
                 });
-            });
         }
 
         /**

--- a/src/FolderCollection.ts
+++ b/src/FolderCollection.ts
@@ -22,8 +22,9 @@ namespace TSLint.MSBuild {
          * Initializes a new instance of the LintRunner class.
          * 
          * @param rootDirectory   The root directory to look at files under.
+         * @param ConfigLoader    The configuration loader.
          */
-        constructor(rootDirectory: string) {
+        constructor(rootDirectory: string, private configLoader: ConfigLoader) {
             this.rootDirectory = rootDirectory;
         }
 
@@ -74,7 +75,7 @@ namespace TSLint.MSBuild {
                 return new Promise(resolve => resolve(folder));
             }
 
-            folder = this.folders[folderPath] = new Folder(folderPath);
+            folder = this.folders[folderPath] = new Folder(folderPath, this.configLoader);
 
             return folder
                 .loadTSLintConfig()

--- a/src/LintRunner.ts
+++ b/src/LintRunner.ts
@@ -36,10 +36,11 @@ namespace TSLint.MSBuild {
          * Initializes a new instance of the LintRunner class.
          * 
          * @param rootDirectory   The root directory to look at files under.
+         * @param configLoader  The configuration loader.
          */
-        constructor(rootDirectory: string) {
+        constructor(rootDirectory: string, private configLoader: ConfigLoader) {
             this.rootDirectory = rootDirectory;
-            this.folders = new FolderCollection(rootDirectory);
+            this.folders = new FolderCollection(rootDirectory, this.configLoader);
             this.tsLintSearcher = new TSLintSearcher();
             this.tsLint = require(this.tsLintSearcher.resolve());
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ namespace TSLint.MSBuild {
         let rootDirectory: string = process.argv[2],
             summaryFilePath: string = process.argv[3],
             filePaths: string[] = getInputFilesList(summaryFilePath),
-            runner = new LintRunner(rootDirectory);
+            runner = new LintRunner(rootDirectory, new ConfigLoader());
 
         console.log(`Running TSLint on ${filePaths.length} files.`);
         console.log(`Root directory is '${rootDirectory}'.`);


### PR DESCRIPTION
Hi, 

I used a very simplistic way to strip the BOM from the config files, rather than inlining strip-bom. 
It does the trick on utf-8 with / without BOM but it might be a good idea to better handle file encodings at some point.

Please do not hesitate to tell me if you'd like to change anything to my code.

Cheers !

Issue : #17 
