### PR TITLE
Bumping up to 3.0 with rules directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TSLint for MSBuild
 
+[![NuGet](https://img.shields.io/nuget/v/Nuget.Core.svg?maxAge=2592000)]()
+
 An MSBuild target for linting TypeScript code using [TSLint](https://github.com/palantir/tslint). Get it at [nuget.org](https://www.nuget.org/packages/TSLint.MSBuild/).
 
 ## Usage
@@ -20,6 +22,7 @@ The following properties may be overidden via your targets:
 * **TSLintFileListDir** - The directory to put the file list in. Defaults to `$(IntermediateOutDir)`.
 * **TSLintFileListName** - The name of the file list file. Defaults to `TSLintFileList.txt-$(MSBuildProjectName)`.
 * **TSLintNodeExe**: A node executable to execute the runner script. Defaults to the `tools\node-5.9.0.exe` in the package. 
+* **TSLintRulesDirectory** - An additional rules directory, for user-created rules. Multiple directories may be separated by commas.
 * **TSLintRunnerScript** - The .js file to take in `TSLintFileListFile`. Defaults to the `tools\runner.js` in the package.
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TSLint for MSBuild
 
-[![NuGet](https://img.shields.io/nuget/v/Nuget.Core.svg?maxAge=2592000)]()
+[![NuGet Version and Downloads count](https://buildstats.info/nuget/TSLint.MSBuild)](https://www.nuget.org/packages/TSLint.MSBuild) 
 
 An MSBuild target for linting TypeScript code using [TSLint](https://github.com/palantir/tslint). Get it at [nuget.org](https://www.nuget.org/packages/TSLint.MSBuild/).
 

--- a/TSLint.MSBuild.nuspec
+++ b/TSLint.MSBuild.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>TSLint.MSBuild</id>
-    <version>0.2.1</version>
+    <version>0.3.0</version>
     <authors>palantir, joshuakgoldberg</authors>
     <owners>joshuakgoldberg</owners>
     <licenseUrl>https://github.com/JoshuaKGoldberg/TSLint.MSBuild/blob/master/LICENSE.md</licenseUrl>
@@ -23,6 +23,6 @@
     <file src="dist\node-*.exe" target="tools" />
     <file src="dist\package.json" target="tools" />
     <file src="dist\README.md" target="tools" />
-    <file src="dist\runner.js" target="tools" />
+    <file src="dist\*.js" target="tools" />
   </files>
 </package>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-msbuild",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": " An MSBuild target for linting TypeScript code using TSLint.",
   "author": "Joshua K Goldberg",
   "license": "MIT",
@@ -11,12 +11,12 @@
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-copy": "^1.0.0",
-    "grunt-exec": "^0.4.6",
+    "grunt-exec": "^0.4.7",
     "grunt-npm-install": "^0.3.0",
     "grunt-nuget": "^0.1.5",
-    "grunt-ts": "^5.4.0",
+    "grunt-ts": "^5.5.1",
     "grunt-tslint": "^3.0.3",
-    "tslint": "^3.7.1",
+    "tslint": "^3.10.2",
     "typescript": "^1.8.9",
     "typings": "^0.7.3"
   }

--- a/src/ArgumentsCollection.ts
+++ b/src/ArgumentsCollection.ts
@@ -8,7 +8,8 @@ export class ArgumentsCollection {
     private static valueSetters: { [i: string]: (value: string) => void } = {
         "exclude": ArgumentsCollection.prototype.setExclude,
         "files-root-dir": ArgumentsCollection.prototype.setFilesRootDir,
-        "file-list-file": ArgumentsCollection.prototype.setFileListFile
+        "file-list-file": ArgumentsCollection.prototype.setFileListFile,
+        "rules-directory": ArgumentsCollection.prototype.setRulesDirectories
     };
 
     /**
@@ -31,6 +32,13 @@ export class ArgumentsCollection {
      * @alias file-list-file
      */
     private fileListFile: string;
+
+    /**
+     * Path(s) to where rules are stored. 
+     * 
+     * @alias rules-directory
+     */
+    private rulesDirectories: string[];
 
     /**
      * Initializes a new instance of the ArgumentsCollection class.
@@ -73,6 +81,13 @@ export class ArgumentsCollection {
     }
 
     /**
+     * @returns The RulesDirectory argument.
+     */
+    public getRulesDirectories(): string[] {
+        return this.rulesDirectories;
+    }
+
+    /**
      * Sets the FilesRootDir argument.
      * 
      * @param value   A new FilesRootDir value.
@@ -97,5 +112,14 @@ export class ArgumentsCollection {
      */
     private setExclude(value: string): void {
         this.exclude = new RegExp(value || "^$", "i");
+    }
+
+    /**
+     * Sets the Exclude argument.
+     * 
+     * @param value   A new Exclude value.
+     */
+    private setRulesDirectories(value: string): void {
+        this.rulesDirectories = value.split(",");
     }
 }

--- a/src/Folder.ts
+++ b/src/Folder.ts
@@ -1,12 +1,12 @@
-/// <reference path="../typings/main/ambient/node/index.d.ts" />
+/// <reference path="../typings/main.d.ts" />
+/// <reference path="./WaitLock.ts" />
 
-const fs = require("fs");
-const path = require("path");
-
+import * as fs from "fs";
+import * as path from "path";
 import { WaitLock } from "./WaitLock";
 
 /**
- * A representation of a directory with files and optionally a tsconfig.json.
+ * A representation of a directory with files and optionally a tslint.json.
  */
 export class Folder {
     /**
@@ -20,12 +20,12 @@ export class Folder {
     private filePaths: string[] = [];
 
     /**
-     * TSLint configuration for this folder, if it exists.
+     * Rules list for this folder, if it exists.
      */
-    private tsLintConfig: any;
+    private rules: any;
 
     /**
-     * Waiter for loading the tslint.json configuration. 
+     * Waiter for loading the tslint.json rules 
      */
     private loadWaiter: WaitLock = new WaitLock();
 
@@ -53,19 +53,19 @@ export class Folder {
     }
 
     /**
-     * @returns TSLint configuration for this folder, if it exists.
+     * @returns Rules list for this folder, if it exists.
      */
-    public getTSLintConfig(): any {
-        return this.tsLintConfig;
+    public getRules(): any {
+        return this.rules;
     }
 
     /**
-     * Sets the TSLint configuration for this folder.
+     * Sets the rules list for this folder.
      * 
-     * @param tsconfig   A new TSLint configuration for this folder.
+     * @param rules   A new rules lits for this folder.
      */
-    public setTSLintConfig(tsconfig: any): any {
-        this.tsLintConfig = tsconfig;
+    public setRules(rules: any): any {
+        this.rules = rules;
         this.loadWaiter.markActionCompletion();
     }
 
@@ -83,30 +83,27 @@ export class Folder {
      * 
      * @returns A Promise for whether a tslint.json was found.
      */
-    public loadTSLintConfig(): Promise<boolean> {
+    public loadRules(): Promise<boolean> {
         this.loadWaiter.markActionStart();
 
         return new Promise(resolve => {
             fs.readFile(path.join(this.path, "tslint.json"), (error, result) => {
                 if (error) {
-                    this.setTSLintConfig(undefined);
+                    this.setRules(undefined);
                     resolve(false);
                     return;
                 }
 
-                this.setTSLintConfig({
-                    formatter: "json",
-                    configuration: this.sanitizeFileContents(result)
-                });
+                this.setRules(this.sanitizeFileContents(result));
                 resolve(true);
             });
         });
     }
 
     /**
-     * Waits for this folder to load its tsconfig.json.
+     * Waits for this folder to load its tslint.json.
      * 
-     * @returns A Promise for this folder to load its tsconfig.json.
+     * @returns A Promise for this folder to load its tslint.json.
      */
     public waitForTSLint(): Promise<Folder> {
         return new Promise(resolve => {

--- a/src/TSLint.MSBuild.targets
+++ b/src/TSLint.MSBuild.targets
@@ -17,8 +17,9 @@
       <TSLintFileListDir Condition="'$(TSLintFileListDir)' == ''">$(IntermediateOutDir)</TSLintFileListDir>
       <TSLintFileListName Condition="'$(TSLintFileListName)' == ''">TSLintFileList-$(MSBuildProjectName).txt</TSLintFileListName>
       <TSLintFileListFile>$(TSLintFileListDir)$(TSLintFileListName)</TSLintFileListFile>
-      <TSLintNodeExe Condition="'$(TSLintNodeExe)' == ''">$([System.IO.Path]::GetFullPath("$(MSBuildThisFileDirectory)\..\tools\node-5.9.0.exe"))</TSLintNodeExe>
-      <TSLintRunnerScript Condition="'$(TSLintRunnerScript)' == ''">$([System.IO.Path]::GetFullPath("$(MSBuildThisFileDirectory)\..\tools\runner.js"))</TSLintRunnerScript>
+      <TSLintNodeExe Condition="'$(TSLintNodeExe)' == ''">$([System.IO.Path]::GetFullPath("$(MSBuildThisFileDirectory)\..\tools\node-6.1.0.exe"))</TSLintNodeExe>
+      <TSLintRulesDirectory Condition="'$(TSLintRulesDirectory)' == ''"></TSLintRulesDirectory>
+      <TSLintRunnerScript Condition="'$(TSLintRunnerScript)' == ''">$([System.IO.Path]::GetFullPath("$(MSBuildThisFileDirectory)\..\tools\index.js"))</TSLintRunnerScript>
     </PropertyGroup>
 
     <ItemGroup>
@@ -34,7 +35,7 @@
 
     <!-- Run TSLint via the runner -->
     <Exec 
-      Command="&quot;$(TSLintNodeExe)&quot; --harmony &quot;$(TSLintRunnerScript)&quot; -exclude &quot;$(TSLintExclude)&quot; -files-root-dir &quot;$(TSLintFilesRootDir)&quot; -file-list-file &quot;$(TSLintFileListFile)&quot;"
+      Command="&quot;$(TSLintNodeExe)&quot; --harmony --harmony_modules &quot;$(TSLintRunnerScript)&quot; -exclude &quot;$(TSLintExclude)&quot; -files-root-dir &quot;$(TSLintFilesRootDir)&quot; -file-list-file &quot;$(TSLintFileListFile)&quot; -rules-directory &quot;$(TSLintRulesDirectory)&quot;"
       IgnoreExitCode="true">
       <Output TaskParameter="ExitCode" PropertyName="ErrorCode" />
     </Exec>

--- a/src/TSLintSearcher.ts
+++ b/src/TSLintSearcher.ts
@@ -1,4 +1,7 @@
-/// <reference path="../typings/main/ambient/node/index.d.ts" />
+/// <reference path="../typings/main.d.ts" />
+
+import * as fs from "fs";
+import * as path from "path";
 
 /**
  * The folder name NuGet packages are stored under.
@@ -16,9 +19,6 @@ const pathSuffix: string = "tools/node_modules/tslint";
 const possibleEnvironmentVariables: string[] = [
     "NugetMachineInstallRoot"
 ];
-
-const fs = require("fs");
-const path = require("path");
 
 /**
  * A utility to find a TSLint NuGet package.

--- a/src/WaitLock.ts
+++ b/src/WaitLock.ts
@@ -22,7 +22,7 @@ export class WaitLock {
      * 
      * @param callback   A callback to be executed.
      */
-    addCallback(callback: Function): void {
+    public addCallback(callback: Function): void {
         if (this.completed) {
             callback();
         } else {
@@ -33,7 +33,7 @@ export class WaitLock {
     /**
      * Marks that an action has started.
      */
-    markActionStart(): void {
+    public markActionStart(): void {
         this.pendingActions += 1;
     }
 
@@ -41,7 +41,7 @@ export class WaitLock {
      * Marks that an action has completed. If all actions have
      * completed, the callbacks queue is drained.
      */
-    markActionCompletion(): void {
+    public markActionCompletion(): void {
         this.pendingActions -= 1;
 
         if (this.pendingActions === 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,9 @@
-/// <reference path="../typings/main/ambient/node/index.d.ts" />
-/// <reference path="ArgumentsCollection.ts" />
-/// <reference path="Folder.ts" />
-/// <reference path="FolderCollection.ts" />
-/// <reference path="LintRunner.ts" />
+/// <reference path="../typings/main.d.ts" />
 
 console.log("Starting TSLint runner.");
 
-const fs = require("fs");
-const path = require("path");
-
+import * as fs from "fs";
+import * as path from "path";
 import { ArgumentsCollection } from "./ArgumentsCollection";
 import { LintRunner } from "./LintRunner";
 
@@ -23,7 +18,7 @@ function getInputFilesList(filePath): string[] {
         .toString()
         .replace(/\r/g, "")
         .split("\n")
-        .filter(file => file);
+        .filter(file => !!file);
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,18 @@
 {
     "compilerOptions": {
-        "outFile": "dist/runner.js",
+        "module": "commonjs",
+        "outDir": "dist",
         "pretty": true,
         "sourceMap": false,
-        "target": "es6"
+        "target": "es2015"
     },
     "files": [
+        "src/ArgumentsCollection.ts",
         "src/Folder.ts",
         "src/FolderCollection.ts",
         "src/index.ts",
-        "src/LintRunner.ts"
+        "src/LintRunner.ts",
+        "src/TSLintSearcher.ts",
+        "src/WaitLock.ts"
     ]
 }


### PR DESCRIPTION
Node 6.1 instead of 5.9, and no more outFile (separate files importing
each other). As TypeScript is meant to be.