### PR TITLE
Added TSLintConfig (--config) option to tslint

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ A .js runner file then takes in the path to that file list, scans for `tslint.js
 
 The following properties may be overidden via your targets:
 * **TSLintBreakBuildOnError** -  Whether linting failures should break the build. Defaults to `false`.
+* **TSLintConfig** - Path to a specific tslint.json. Defaults to blank, for any tslint.json on the path.
 * **TSLintDeleteFileListFile** - Whether to delete the file list file when done. Defaults to `true`.
-* **TSLintExclude** - Blob of matching file names to exclude. Defaults to none
+* **TSLintExclude** - Blob of matching file names to exclude. Defaults to none.
 * **TSLintFilesRootDir** - Root directory to work within. Defaults to `$(MSBuildProjectDirectory)`.
 * **TSLintFileListDir** - Directory to put the file list in. Defaults to `$(IntermediateOutDir)`.
 * **TSLintFileListName** - Name of the file list file. Defaults to `TSLintFileList.txt-$(MSBuildProjectName)`.
-* **TSLintNodeExe**: Node executable to execute the runner script. Defaults to the `tools\node-5.9.0.exe` in the package. 
+* **TSLintNodeExe**: Node executable to execute the runner script. Defaults to the `tools\node-6.1.0.exe` in the package. 
 * **TSLintRulesDirectory** - Comma-separated list of directories for user-created rules. Defaults to none.
 * **TSLintRunnerScript** - The .js file to take in `TSLintFileListFile`. Defaults to the `tools\runner.js` in the package.
 

--- a/src/ArgumentsCollection.ts
+++ b/src/ArgumentsCollection.ts
@@ -3,6 +3,11 @@
  */
 interface ICollected {
     /**
+     * Path to a specific tslint.json.
+     */
+    "--config"?: string;
+
+    /**
      * A glob path to exclude from linting.
      */
     "--exclude"?: string;
@@ -31,14 +36,14 @@ export class ArgumentsCollection {
      * Whitelist of allowed keys from the .targets file.
      */
     private static allowedKeys: Set<string> = new Set<string>([
-        "--file-list-file", "--files-root-dir", "--exclude", "--rules-directory"
+        "--config", "--exclude", "--file-list-file", "--files-root-dir", "--rules-directory"
     ]);
 
     /**
      * Keys to pass to the TSLint CLI.
      */
     private static cliKeys: Set<string> = new Set<string>([
-        "--exclude", "--rules-directory"
+        "--config", "--exclude", "--rules-directory"
     ]);
 
     /**
@@ -81,6 +86,13 @@ export class ArgumentsCollection {
     }
 
     /**
+     * @returns The path to a specific tslint.json.
+     */
+    public getConfig(): string {
+        return this.collected["--config"];
+    }
+
+    /**
      * @returns The root directory to work within.
      */
     public getFilesRootDir(): string {
@@ -103,7 +115,7 @@ export class ArgumentsCollection {
         const args: string[] = [];
 
         for (const key of ArgumentsCollection.cliKeys) {
-            if (this.collected.hasOwnProperty(key)) {
+            if (this.collected[key]) {
                 args.push(key, this.collected[key]);
             }
         }

--- a/src/TSLint.MSBuild.targets
+++ b/src/TSLint.MSBuild.targets
@@ -11,8 +11,9 @@
     Name="TSLint">
     <PropertyGroup>
       <TSLintBreakBuildOnError Condition="'$(TSLintBreakBuildOnError)' == ''">false</TSLintBreakBuildOnError>
+      <TSLintConfig Condition="'$(TSLintConfig)' == ''"></TSLintConfig>
       <TSLintDeleteFileListFile Condition="'$(TSLintDeleteFileListFile)' == ''">true</TSLintDeleteFileListFile>
-      <TSLintExclude Condition="'$(TSLintExclude)' == ''">^$</TSLintExclude>
+      <TSLintExclude Condition="'$(TSLintExclude)' == ''"></TSLintExclude>
       <TSLintFilesRootDir Condition="'$(TSLintFilesRootDir)' == ''">$(MSBuildProjectDirectory)</TSLintFilesRootDir>
       <TSLintFileListDir Condition="'$(TSLintFileListDir)' == ''">$(IntermediateOutDir)</TSLintFileListDir>
       <TSLintFileListName Condition="'$(TSLintFileListName)' == ''">TSLintFileList-$(MSBuildProjectName).txt</TSLintFileListName>
@@ -35,7 +36,7 @@
 
     <!-- Run TSLint via the runner -->
     <Exec 
-      Command="&quot;$(TSLintNodeExe)&quot; --harmony --harmony_modules &quot;$(TSLintRunnerScript)&quot; --exclude &quot;$(TSLintExclude)&quot; --file-list-file &quot;$(TSLintFileListFile)&quot; --files-root-dir &quot;$(TSLintFilesRootDir)&quot; --rules-directory &quot;$(TSLintRulesDirectory)&quot;"
+      Command="&quot;$(TSLintNodeExe)&quot; --harmony --harmony_modules &quot;$(TSLintRunnerScript)&quot; --config &quot;$(TSLintConfig)&quot; --exclude &quot;$(TSLintExclude)&quot; --file-list-file &quot;$(TSLintFileListFile)&quot; --files-root-dir &quot;$(TSLintFilesRootDir)&quot; --rules-directory &quot;$(TSLintRulesDirectory)&quot;"
       IgnoreExitCode="true">
       <Output TaskParameter="ExitCode" PropertyName="ErrorCode" />
     </Exec>


### PR DESCRIPTION
Changed ArgumentsCollection to only add non-falsy keys to spawned arguments. Having a blank `--config` causes tslint's CLI to error.

Fixes #42.