### PR TITLE
Find tslint-cli.js in directory with spaces

### DIFF
--- a/src/build/TSLint.MSBuild.targets
+++ b/src/build/TSLint.MSBuild.targets
@@ -48,7 +48,7 @@
 
     <!-- Run TSLint using the Node executable -->
     <Exec
-      Command="&quot;$(TSLintNodeExe)&quot; $(TSLintCli) $(TSLintArgs)"
+      Command="&quot;$(TSLintNodeExe)&quot; &quot;$(TSLintCli)&quot; $(TSLintArgs)"
       Condition="'$(TSLintDisabled)' != 'true'"
       ConsoleToMsBuild="true"
       EchoOff="true"


### PR DESCRIPTION
Added quotes to make it possible to find tslint-cli.js when solution directory contains spaces