### PR TITLE
Added the option to override --format

### DIFF
--- a/src/build/TSLint.MSBuild.targets
+++ b/src/build/TSLint.MSBuild.targets
@@ -13,6 +13,7 @@
     <!-- PropertyGroup settings -->
     <PropertyGroup>
       <TSLintBreakBuildOnError Condition="'$(TSLintBreakBuildOnError)' == ''">false</TSLintBreakBuildOnError>
+      <TSLintFormat Condition="'$(TSLintFormat)' == ''">msbuild</TSLintFormat>
       <TSLintNodeExe Condition="'$(TSLintNodeExe)' == ''">$([System.IO.Path]::GetFullPath("$(MSBuildThisFileDirectory)..\tools\node-7.3.0.exe"))</TSLintNodeExe>
       <TSLintTimeout Condition="'$(TSLintTimeout)' == ''">10000000</TSLintTimeout>
       <TSLintVersion Condition="'$(TSLintVersion)' == ''">*.*.*</TSLintVersion>
@@ -40,7 +41,7 @@
       <TSLintArgs></TSLintArgs>
       <TSLintArgs Condition="'$(TSLintConfig)' != ''">$(TSLintArgs) --config $(TSLintConfig)</TSLintArgs>
       <TSLintArgs Condition="'@(TSLintExclude)' != ''">$(TSLintArgs) --exclude $(TSLintExcludeJoined)</TSLintArgs>
-      <TSLintArgs>$(TSLintArgs) --format msbuild</TSLintArgs>
+      <TSLintArgs>$(TSLintArgs) --format $(TSLintFormat)</TSLintArgs>
       <TSLintArgs Condition="'$(TSLintProject)' != ''">$(TSLintArgs) --project $(TSLintProject)</TSLintArgs>
       <TSLintArgs Condition="'$(TSLintTypeCheck)' != ''">$(TSLintArgs) --type-check $(TSLintTypeCheck)</TSLintArgs>
       <TSLintArgs Condition="'@(TSLintRulesDirectory)' != ''">$(TSLintArgs) --rules-dir @(TSLintRulesDirectory, ' --rules-dir ')</TSLintArgs>

--- a/test/TSLintArgs/TSLintArgs/TSLintArgs.csproj
+++ b/test/TSLintArgs/TSLintArgs/TSLintArgs.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
   <PropertyGroup>
     <TSLintDisabled>true</TSLintDisabled>
+    <TSLintFormat>json</TSLintFormat>
     <TSLintConfig>tslint.json</TSLintConfig>
     <TSLintExtraArgs>--baz qux</TSLintExtraArgs>
     <TSLintProject>tsconfig.json</TSLintProject>
@@ -36,7 +37,7 @@
   <!-- Post-TSLint verification -->
   <Target AfterTargets="TSLint" Name="Test">
     <PropertyGroup>
-      <TSLintArgsExpected> --config tslint.json --exclude foo.ts --exclude bar.ts --format msbuild --project tsconfig.json --type-check true --rules-dir rules/foo --rules-dir rules/bar --baz qux foo.ts bar.ts baz.ts qux.ts</TSLintArgsExpected>
+      <TSLintArgsExpected> --config tslint.json --exclude foo.ts --exclude bar.ts --format json --project tsconfig.json --type-check true --rules-dir rules/foo --rules-dir rules/bar --baz qux foo.ts bar.ts baz.ts qux.ts</TSLintArgsExpected>
     </PropertyGroup>
 
     <Error


### PR DESCRIPTION
Taken in as `TSLintFormat` with a default still set to `msbuild`.

Fixes #69.