### PR TITLE
Fix for issue #97- The timestamp file used for incremental builds should only be touched if tslint succeeds

### DIFF
--- a/src/build/TSLint.MSBuild.targets
+++ b/src/build/TSLint.MSBuild.targets
@@ -84,6 +84,11 @@
       <Output TaskParameter="ExitCode" PropertyName="TSLintErrorCode" />
     </Exec>
 
+    <Touch
+      Condition="'$(TSLintCreateTimestampFile)' == 'true' and $(TSLintErrorCode) == 0"
+      AlwaysCreate="true"
+      Files="$(TSLintTimestampFile)" />
+
     <!-- Return an error if TSLint returned an exit code and we should break on errors -->
     <Error Condition="'$(TSLintErrorCode)' != '0' and '$(TSLintBreakBuildOnError)' == 'true'" Text="TSLint checks failed" />
   </Target>

--- a/src/build/TSLint.MSBuild.targets
+++ b/src/build/TSLint.MSBuild.targets
@@ -67,11 +67,6 @@
 
     <MakeDir Directories="$(OutputPath)" />
 
-    <Touch
-      Condition="'$(TSLintCreateTimestampFile)' == 'true'"
-      AlwaysCreate="true"
-      Files="$(TSLintTimestampFile)" />
-
     <!-- Run TSLint using the Node executable -->
     <Exec
       Command="&quot;$(TSLintNodeExe)&quot; &quot;$(TSLintCli)&quot; $(TSLintArgs)"


### PR DESCRIPTION
Just moved the touch to after the tslint execution and added a tslint error code check to the touch task.