### PR TITLE
TSLintPotentialCli search now considers the new folder structure for packages

### DIFF
--- a/src/build/TSLint.MSBuild.targets
+++ b/src/build/TSLint.MSBuild.targets
@@ -33,7 +33,9 @@
     <!-- Grab the first matching TSLint CLI in a NuGet packages install -->
     <ItemGroup Condition="'$(TSLintCli)' == ''">
       <TSLintPotentialCli Include="$(SolutionDir)packages\tslint.$(TSLintVersion)\tools\node_modules\tslint\lib\tslint-cli.js" />
+      <TSLintPotentialCli Include="$(SolutionDir)packages\tslint\$(TSLintVersion)\tools\node_modules\tslint\lib\tslint-cli.js" />
       <TSLintPotentialCli Include="$(MSBuildThisFileDirectory)..\..\tslint.$(TSLintVersion)\tools\node_modules\tslint\lib\tslint-cli.js" />
+      <TSLintPotentialCli Include="$(MSBuildThisFileDirectory)..\..\..\tslint\$(TSLintVersion)\tools\node_modules\tslint\lib\tslint-cli.js" />
       <TSLintPotentialCli Include="$(ProjectDir)node_modules\tslint\bin\tslint" />
     </ItemGroup>
     <PropertyGroup Condition="'$(TSLintCli)' == ''">


### PR DESCRIPTION
Adding the cases considering the new folder structure for packages when searching for `TSLintPotentialCli`.

Fixes #98.