### PR TITLE
Fix false error when TSLintDisabled is true

### DIFF
--- a/src/build/TSLint.MSBuild.targets
+++ b/src/build/TSLint.MSBuild.targets
@@ -92,6 +92,6 @@
       Files="$(TSLintTimestampFile)" />
 
     <!-- Return an error if TSLint returned an exit code and we should break on errors -->
-    <Error Condition="'$(TSLintErrorCode)' != '0' and '$(TSLintBreakBuildOnError)' == 'true'" Text="TSLint checks failed" />
+    <Error Condition="'$(TSLintDisabled)' != 'true' and '$(TSLintErrorCode)' != '0' and '$(TSLintBreakBuildOnError)' == 'true'" Text="TSLint checks failed" />
   </Target>
 </Project>


### PR DESCRIPTION
When TSLintDisabled is true, TSLintErrorCode never gets set to 0, so this error task always emits an error.

Other possible solutions - I'm open to suggestions:
* Check TSLintDisabled from the target conditions
* Set TSLintErrorCode to 0 if TSLintDisabled is true